### PR TITLE
Extract attributes into enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,4 +1,4 @@
 [root]
 name = "straw"
-version = "0.1.0"
+version = "0.2.0"
 

--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@ Import `Element` and `Renderable` and start creating `Element`s.
 extern crate straw;
 
 use straw::element::{Element, Renderable}
+use straw::attribute::Attr;
 
-let element = Element::new("div", Some(vec![("id", "main")]), vec![
-  Element::new("h1", None, "Hello"),
-  Element::new("h1", None, "World"),
+let element = Element::new("div", vec![Attr::id("main")], vec![
+  Element::new("h1", vec![], "Hello"),
+  Element::new("input", vec![Attr::disabled(true)], ""),
 ]);
 
-element.render(); // <div id="main"><h1>Hello</h1><h1>World</h1></div>
+element.render(); // <div id="main"><h1>Hello</h1><input disabled></input></div>
 ```

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -1,0 +1,166 @@
+pub enum Attr {
+    KeyValue(String, String),
+    Bool(String, bool),
+}
+
+macro_rules! key_value {
+    ($x:ident) => {
+        #[allow(non_snake_case)]
+        pub fn $x<S: Into<String>>(value: S) -> Attr {
+            Attr::KeyValue(stringify!($x).to_owned(), value.into())
+        }
+    };
+
+    ( $( $x:ident ),* ) => {
+        $(
+            key_value!($x);
+        )*
+    }
+}
+
+macro_rules! bool_attribute {
+    ($x:ident) => {
+        #[allow(non_snake_case)]
+        pub fn $x(conditional: bool) -> Attr {
+            Attr::Bool(stringify!($x).to_owned(), conditional)
+        }
+    };
+
+    ( $( $x:ident ),* ) => {
+        $(
+            bool_attribute!($x);
+        )*
+    }
+}
+
+impl Attr {
+    // loop, for, type are keywords and can't be defined as functions
+    bool_attribute!(
+        async,
+        autofocus,
+        checked,
+        compact,
+        declare,
+        default,
+        defer,
+        disabled,
+        formnovalidate,
+        hidden,
+        ismap,
+        multiple,
+        noresize,
+        novalidate,
+        readonly,
+        required,
+        reversed,
+        seamless,
+        selected
+    );
+
+    key_value!(
+        accesskey,
+        align,
+        attribute,
+        challenge,
+        charset,
+        cite,
+        colspan,
+        content,
+        contenteditable,
+        contextmenu,
+        datetime,
+        dir,
+        draggable,
+        dropzone,
+        headers,
+        httpEquiv,
+        itemprop,
+        keytype,
+        kind,
+        lang,
+        language,
+        manifest,
+        poster,
+        property,
+        pubdate,
+        rowspan,
+        sandbox,
+        scope,
+        scoped,
+        spellcheck,
+        srcdoc,
+        srclang,
+        start,
+        tabindex,
+        preload,
+        alt,
+        autoplay,
+        cols,
+        controls,
+        coords,
+        download,
+        downloadAs,
+        height,
+        href,
+        hreflang,
+        max,
+        media,
+        min,
+        ping,
+        rel,
+        rows,
+        shape,
+        src,
+        step,
+        target,
+        usemap,
+        width,
+        wrap,
+        form,
+        accept,
+        acceptCharset,
+        action,
+        autocomplete,
+        autosave,
+        class,
+        classList,
+        enctype,
+        formaction,
+        id,
+        key,
+        list,
+        maxlength,
+        method,
+        minlength,
+        name,
+        pattern,
+        placeholder,
+        size,
+        style,
+        title,
+        value
+    );
+
+    pub fn key_value<S: Into<String>>(key: S, value: S) -> Attr {
+        Attr::KeyValue(key.into(), value.into())
+    }
+
+    pub fn boolean<S: Into<String>>(key: S, conditional: bool) -> Attr {
+        Attr::Bool(key.into(), conditional)
+    }
+
+    pub fn render(&self) -> Option<String> {
+        match *self {
+            Attr::KeyValue(ref key, ref value) => {
+                Some(format!("{}=\"{}\"", key, value))
+            },
+            Attr::Bool(ref key, ref conditional) => {
+                if *conditional {
+                    Some(key.clone())
+                } else {
+                    None
+                }
+            },
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod element;
+pub mod attribute;


### PR DESCRIPTION
This extracts attributes into an enum that accepts key/value style
attributes and boolean attributes.

Elements no longer take an optional vec of two string tuples and instead
now take a vector of `Attr`s

e.g.

```
Element::new("input", vec![Attr::new("id", "awesome"), Attr::bool("disabled", true)], "");
```
